### PR TITLE
Update aiohttp from 3.8 to 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     scripts=['bin/appointments'],
     python_requires='>=3.10',
     install_requires=[
-        'aiohttp==3.8.4',
+        'aiohttp==3.9.5',
         'beautifulsoup4==4.10.0',
         'chime==0.7.0',
         'pytz',


### PR DESCRIPTION
Looks like this isn't working with Python 3.12+, as the `aiohttp` v3.8 dependency doesn't support Python 3.12. But `aiohttp` v3.9 does.

The latest release is using `aiohttp==3.8.4`

This causes these errors when trying to install:
* `Py_OptimizeFlag` and `ma_version_tag` are being used in the source code of aiohttp, which are no longer supported in Python 3.12
* `ob_digit` in the `_websocket.c` file suggest that there's C code within aiohttp that is incompatible with the Python 3.12 C API

Suggestion: update `aiohttp==3.9.5` to support more modern Python versions

