### PR TITLE
Upgrade python dependancies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,11 @@ setup(
     scripts=['bin/appointments'],
     python_requires='>=3.10',
     install_requires=[
-        'aiohttp==3.9.5',
-        'beautifulsoup4==4.10.0',
+        'aiohttp==3.11.11',
+        'beautifulsoup4==4.12.3',
         'chime==0.7.0',
         'pytz',
-        'websockets==10.1',
+        'websockets==14.2',
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
This makes aiohttp work on Python 3.13 - but also why not upgrade the other libraries too